### PR TITLE
Added missing comma to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "components"
   ],
   "dependencies": {
-    "angular": ">=1.0.6"
+    "angular": ">=1.0.6",
     "hamsterjs": ">=1.0.2"
   }
 }


### PR DESCRIPTION
I tried this morning to install your package and ran into a 

`bower angular-mousewheel#*  EMALFORMED Failed to read [...]/bower.json`

Looks like you're missing a comma :)
