### PR TITLE
angular-mousewheel npm package availability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+node_modules

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2016
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The event callback receives 3 extra arguments which are the normalized “deltas
 Install
 -------
 
-    bower install angular-mousewheel
+    bower install angular-mousewheel or npm install angular-mousewheel
 
 Include [Hamster.js](https://github.com/monospaced/hamster.js) and the `mousewheel.js` script provided by this component in your app, and add `monospaced.mousewheel` to your app’s dependencies.
 

--- a/package.json
+++ b/package.json
@@ -5,14 +5,14 @@
   "main": "mousewheel.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ntinoco96/angular-mousewheel.git"
+    "url": "git+https://github.com/monospaced/angular-mousewheel.git"
   },
   "author": "",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/ntinoco96/angular-mousewheel/issues"
+    "url": "https://github.com/monospaced/angular-mousewheel/issues"
   },
-  "homepage": "https://github.com/ntinoco96/angular-mousewheel#readme",
+  "homepage": "https://github.com/monospaced/angular-mousewheel#readme",
   "dependencies": {
     "angular": "^1.0.6",
     "hamsterjs": "^1.0.2"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "angular-mousewheel",
+  "version": "1.0.4",
+  "description": "Angular Mousewheel",
+  "main": "mousewheel.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ntinoco96/angular-mousewheel.git"
+  },
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/ntinoco96/angular-mousewheel/issues"
+  },
+  "homepage": "https://github.com/ntinoco96/angular-mousewheel#readme",
+  "dependencies": {
+    "angular": "^1.0.6",
+    "hamsterjs": "^1.0.2"
+  }
+}


### PR DESCRIPTION
Hello @monospaced ,

I am working on a project where I am using the npm version of angular-pan-zoom which uses angular-mousewheel as a dependancy.  My company projects depends on npm and not bower for dependancies and webpack (npm) for bundling.   I am offering this change to make angular-mousewheel npm compatible. 
- angular-pan-zoom
    - angular-mousewheel **(no npm package)**
          - angular.js
          - hamster.js

Once you accept this pull request it also **needs to be published to npm**. 
